### PR TITLE
New DNS Provider: Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
-# Hetzner DNS for `libdns`
+# Vercel DNS for `libdns`
 
-[![godoc reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/libdns/hetzner)
+<!-- [![godoc reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/libdns/hetzner) -->
 
 
-This package implements the libdns interfaces for the [Hetzner DNS API](https://dns.hetzner.com/api-docs)
+This package implements the libdns interfaces for the [Vercel DNS API](https://vercel.com/docs/api#endpoints/dns)
 
 ## Authenticating
 
-To authenticate you need to supply a Hetzner [Auth-API-Token](https://dns.hetzner.com/api-docs#section/Authentication/Auth-API-Token).
-
-## Example
-
-Here's a minimal example of how to get all DNS records for zone. See also: [provider_test.go](https://github.com/libdns/hetzner/blob/master/provider_test.go)
+To authenticate you need to supply a Vercel [APIToken](https://vercel.com/docs/api#api-basics/authentication).
+For Testing purposes you can get a Testing Token from your Vercel dashboard.
 
 ```go
 package main
@@ -22,23 +19,23 @@ import (
 	"os"
 	"time"
 
-	"github.com/libdns/libdns/hetzner"
+	"github.com/fairhat/libdns-vercel"
 )
 
 func main() {
-	token := os.Getenv("LIBDNS_HETZNER_TOKEN")
+	token := os.Getenv("LIBDNS_VERCEL_TOKEN")
 	if token == "" {
-		fmt.Printf("LIBDNS_HETZNER_TOKEN not set\n")
+		fmt.Printf("LIBDNS_VERCEL_TOKEN not set\n")
 		return
 	}
 
-	zone := os.Getenv("LIBDNS_HETZNER_ZONE")
+	zone := os.Getenv("LIBDNS_VERCEL_ZONE")
 	if token == "" {
-		fmt.Printf("LIBDNS_HETZNER_ZONE not set\n")
+		fmt.Printf("LIBDNS_VERCEL_ZONE not set\n")
 		return
 	}
 
-	p := &hetzner.Provider{
+	p := &vercel.Provider{
 		AuthAPIToken: token,
 	}
 

--- a/client.go
+++ b/client.go
@@ -1,14 +1,13 @@
-package hetzner
+package vercel
 
 import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -16,36 +15,25 @@ import (
 )
 
 type getAllRecordsResponse struct {
-	Records []record `json:"records"`
-}
-
-type getAllZonesResponse struct {
-	Zones []zone `json:"zones"`
+	Records []VercelRecord `json:"records"`
 }
 
 type createRecordResponse struct {
-	Record record `json:"record"`
+	Uid string `json:"uid"`
 }
 
-type updateRecordResponse struct {
-	Record record `json:"record"`
-}
-
-type zone struct {
-	ID string `json:"id"`
-}
-
-type record struct {
-	ID     string `json:"id,omitempty"`
-	ZoneID string `json:"zone_id,omitempty"`
-	Type   string `json:"type"`
-	Name   string `json:"name"`
-	Value  string `json:"value"`
-	TTL    int    `json:"ttl"`
+type VercelRecord struct {
+	Id    string `json:"id,omitempty"`
+	Type  string `json:"type"`
+	Name  string `json:"name"`
+	Value string `json:"value"`
+	TTL   int    `json:"ttl"`
 }
 
 func doRequest(token string, request *http.Request) ([]byte, error) {
-	request.Header.Add("Auth-API-Token", token)
+	// Bearer Token for Vercel Authorization: Bearer <TOKEN>
+	request.Header.Add("Authorization", "Bearer "+token)
+	request.Header.Add("Content-Type", "application/json")
 
 	client := &http.Client{}
 	response, err := client.Do(request)
@@ -54,7 +42,9 @@ func doRequest(token string, request *http.Request) ([]byte, error) {
 	}
 
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, fmt.Errorf("%s (%d)", http.StatusText(response.StatusCode), response.StatusCode)
+		defer response.Body.Close()
+		data, _ := ioutil.ReadAll(response.Body)
+		return data, fmt.Errorf("%s (%d)", http.StatusText(response.StatusCode), response.StatusCode)
 	}
 
 	defer response.Body.Close()
@@ -66,32 +56,12 @@ func doRequest(token string, request *http.Request) ([]byte, error) {
 	return data, nil
 }
 
-func getZoneID(ctx context.Context, token string, zone string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://dns.hetzner.com/api/v1/zones?name=%s", url.QueryEscape(zone)), nil)
-	data, err := doRequest(token, req)
-	if err != nil {
-		return "", err
-	}
-
-	result := getAllZonesResponse{}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return "", err
-	}
-
-	if len(result.Zones) > 1 {
-		return "", errors.New("zone is ambiguous")
-	}
-
-	return result.Zones[0].ID, nil
-}
-
 func getAllRecords(ctx context.Context, token string, zone string) ([]libdns.Record, error) {
-	zoneID, err := getZoneID(ctx, token, zone)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.vercel.com/v4/domains/%s/records", zone), nil)
 	if err != nil {
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://dns.hetzner.com/api/v1/records?zone_id=%s", zoneID), nil)
 	data, err := doRequest(token, req)
 	if err != nil {
 		return nil, err
@@ -105,7 +75,7 @@ func getAllRecords(ctx context.Context, token string, zone string) ([]libdns.Rec
 	records := []libdns.Record{}
 	for _, r := range result.Records {
 		records = append(records, libdns.Record{
-			ID:    r.ID,
+			ID:    r.Id,
 			Type:  r.Type,
 			Name:  r.Name,
 			Value: r.Value,
@@ -117,17 +87,11 @@ func getAllRecords(ctx context.Context, token string, zone string) ([]libdns.Rec
 }
 
 func createRecord(ctx context.Context, token string, zone string, r libdns.Record) (libdns.Record, error) {
-	zoneID, err := getZoneID(ctx, token, zone)
-	if err != nil {
-		return libdns.Record{}, err
-	}
-
-	reqData := record{
-		ZoneID: zoneID,
-		Type:   r.Type,
-		Name:   normalizeRecordName(r.Name, zone),
-		Value:  r.Value,
-		TTL:    int(r.TTL.Seconds()),
+	reqData := VercelRecord{
+		Type:  r.Type,
+		Name:  normalizeRecordName(r.Name, zone),
+		Value: r.Value,
+		TTL:   int(math.Max((r.TTL.Seconds()), 60)),
 	}
 
 	reqBuffer, err := json.Marshal(reqData)
@@ -135,7 +99,10 @@ func createRecord(ctx context.Context, token string, zone string, r libdns.Recor
 		return libdns.Record{}, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://dns.hetzner.com/api/v1/records", bytes.NewBuffer(reqBuffer))
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("https://api.vercel.com/v2/domains/%s/records", zone), bytes.NewBuffer(reqBuffer))
+	if err != nil {
+		return libdns.Record{}, err
+	}
 	data, err := doRequest(token, req)
 	if err != nil {
 		return libdns.Record{}, err
@@ -147,16 +114,19 @@ func createRecord(ctx context.Context, token string, zone string, r libdns.Recor
 	}
 
 	return libdns.Record{
-		ID:    result.Record.ID,
-		Type:  result.Record.Type,
-		Name:  result.Record.Name,
-		Value: result.Record.Value,
-		TTL:   time.Duration(result.Record.TTL) * time.Second,
+		ID:    result.Uid,
+		Type:  r.Type,
+		Name:  normalizeRecordName(r.Name, zone),
+		Value: r.Value,
 	}, nil
 }
 
-func deleteRecord(ctx context.Context, token string, record libdns.Record) error {
-	req, err := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("https://dns.hetzner.com/api/v1/records/%s", record.ID), nil)
+func deleteRecord(ctx context.Context, zone string, token string, record libdns.Record) error {
+	req, err := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("https://api.vercel.com/v2/domains/%s/records/%s", zone, record.ID), nil)
+	if err != nil {
+		return err
+	}
+
 	_, err = doRequest(token, req)
 	if err != nil {
 		return err
@@ -166,42 +136,18 @@ func deleteRecord(ctx context.Context, token string, record libdns.Record) error
 }
 
 func updateRecord(ctx context.Context, token string, zone string, r libdns.Record) (libdns.Record, error) {
-	zoneID, err := getZoneID(ctx, token, zone)
+	err := deleteRecord(ctx, zone, token, r)
+
 	if err != nil {
 		return libdns.Record{}, err
 	}
 
-	reqData := record{
-		ZoneID: zoneID,
-		Type:   r.Type,
-		Name:   normalizeRecordName(r.Name, zone),
-		Value:  r.Value,
-		TTL:    int(r.TTL.Seconds()),
-	}
-
-	reqBuffer, err := json.Marshal(reqData)
+	newRecord, err := createRecord(ctx, token, zone, r)
 	if err != nil {
 		return libdns.Record{}, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("https://dns.hetzner.com/api/v1/records/%s", r.ID), bytes.NewBuffer(reqBuffer))
-	data, err := doRequest(token, req)
-	if err != nil {
-		return libdns.Record{}, err
-	}
-
-	result := updateRecordResponse{}
-	if err := json.Unmarshal(data, &result); err != nil {
-		return libdns.Record{}, err
-	}
-
-	return libdns.Record{
-		ID:    result.Record.ID,
-		Type:  result.Record.Type,
-		Name:  result.Record.Name,
-		Value: result.Record.Value,
-		TTL:   time.Duration(result.Record.TTL) * time.Second,
-	}, nil
+	return newRecord, nil
 }
 
 func createOrUpdateRecord(ctx context.Context, token string, zone string, r libdns.Record) (libdns.Record, error) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/libdns/hetzner
+module github.com/fairhat/libdns-vercel
 
 go 1.14
 

--- a/provider.go
+++ b/provider.go
@@ -1,4 +1,4 @@
-package hetzner
+package vercel
 
 import (
 	"context"
@@ -7,9 +7,9 @@ import (
 	"github.com/libdns/libdns"
 )
 
-// Provider implements the libdns interfaces for Hetzner
+// Provider implements the libdns interfaces for Vercel
 type Provider struct {
-	// AuthAPIToken is the Hetzner Auth API token - see https://dns.hetzner.com/api-docs#section/Authentication/Auth-API-Token
+	// AuthAPIToken is the Vercel Authentication Token - see https://vercel.com/docs/api#api-basics/authentication
 	AuthAPIToken string `json:"auth_api_token"`
 }
 
@@ -39,9 +39,9 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 }
 
 // DeleteRecords deletes the records from the zone.
-func (p *Provider) DeleteRecords(ctx context.Context, _ string, records []libdns.Record) ([]libdns.Record, error) {
+func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []libdns.Record) ([]libdns.Record, error) {
 	for _, record := range records {
-		err := deleteRecord(ctx, p.AuthAPIToken, record)
+		err := deleteRecord(ctx, unFQDN(zone), p.AuthAPIToken, record)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 	return setRecords, nil
 }
 
-// unFQDN trims any trailing "." from fqdn. Hetzner's API does not use FQDNs.
+// unFQDN trims any trailing "." from fqdn. Vercel's API does not use FQDNs.
 func unFQDN(fqdn string) string {
 	return strings.TrimSuffix(fqdn, ".")
 }


### PR DESCRIPTION
Hello,

I've forked the Hetzner Repository and modified it to work with domains that are managed by Vercel (vercel.com).
It uses the vercel API, the tests pass (just not the TTL value in GetRecord since Vercel's API does not return any TTL values).

Can we get this as an official libdns package? (I would like to use it on Caddyserver)

I didn't know where to open the request, obviously this i don't want this to be merged into hetzner.