### PR TITLE
Update libdns to v0.2.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/libdns/hetzner
 
-go 1.14
+go 1.17
 
-require github.com/libdns/libdns v0.1.0
+require github.com/libdns/libdns v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.1.0 h1:0ctCOrVJsVzj53mop1angHp/pE3hmAhP7KiHvR0HD04=
-github.com/libdns/libdns v0.1.0/go.mod h1:yQCXzk1lEZmmCPa857bnk4TsOiqYasqpyOEeSObbb40=
+github.com/libdns/libdns v0.2.2 h1:O6ws7bAfRPaBsgAYt8MDe2HcNBGC29hkZ9MX2eUSX3s=
+github.com/libdns/libdns v0.2.2/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=


### PR DESCRIPTION
Hi there,

this commit will update libdns to v0.2.2. This is required by [OPNsense Caddy plugin](https://github.com/opnsense/plugins/issues/3872) because [Caddy DNS Hetzner](https://github.com/caddy-dns/hetzner) relies on this library instead of libdns directly.

I don't see any conflicts in this pull request and hope it will be accepted.