### PR TITLE
Correctly handle not_found errors in GetRecords

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -3,6 +3,7 @@ package hetzner
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 
@@ -74,6 +75,8 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 	hcloudZone, _, err := p.getClient().Zone.Get(ctx, unFQDN(zone))
 	if err != nil {
 		return nil, err
+	} else if hcloudZone == nil {
+		return nil, fmt.Errorf("zone '%s' not found at Hetzner", zone)
 	}
 
 	sets, err := p.getClient().Zone.AllRRSets(ctx, hcloudZone)


### PR DESCRIPTION
The fixes a bug brought up in https://github.com/caddy-dns/hetzner/issues/17.

If the given zone name doesn't exist, hcloud's `Zone.Get()` returns `nil, resp, nil` and not an error. Handle the returned zone being nil gracefully instead of continuing, which results in a panic later on.

All other Provider functions aren't affected, they don't use `Zone.Get()` but rather other hcloud functions that return a Go error with description "Zone not found (not_found, <trace-id)".
